### PR TITLE
Support for flasher images

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,11 +27,11 @@ extern crate maplit;
 
 mod args;
 mod config_json;
-mod join;
-mod leave;
 mod errors;
 mod fs;
 mod generate;
+mod join;
+mod leave;
 mod logger;
 mod os_config;
 mod os_config_api;
@@ -40,8 +40,6 @@ mod update;
 
 use args::{get_cli_args, OsConfigSubcommand};
 use errors::*;
-
-const SUPERVISOR_SERVICE: &str = "resin-supervisor.service";
 
 fn main() {
     if let Err(ref e) = run() {

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -85,6 +85,24 @@ pub fn await_service_exit_impl(name: &str) -> Result<()> {
     bail!(ErrorKind::AwaitServiceExitTimeout)
 }
 
+pub fn service_exists(name: &str) -> bool {
+    match service_exists_impl(name) {
+        Ok(result) => result,
+        Err(_) => false,
+    }
+}
+
+fn service_exists_impl(name: &str) -> Result<bool> {
+    let connection = dbus::Connection::get_private(dbus::BusType::System)?;
+
+    let path = connection.with_path(SYSTEMD, SYSTEMD_PATH, 5000);
+
+    match path.get_unit(name) {
+        Ok(_) => Ok(true),
+        Err(_) => Ok(false),
+    }
+}
+
 pub trait OrgFreedesktopSystemd1Manager {
     fn get_unit(&self, name: &str) -> Result<dbus::Path<'static>>;
     fn start_unit(&self, name: &str, mode: &str) -> Result<dbus::Path<'static>>;


### PR DESCRIPTION
If `/mnt/boot/resin-image-flasher` exists on the filesystem an alternative location for config.json is used: `/tmp/config.json`.

If the `resin-supervisor.service` systemd unit does not exists, then we never attempt to stop/start the supervisor service.

Two new integration tests are included for those two cases.